### PR TITLE
Denote `holidays` version as `>=0.16`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 packages =
     energy_datetime
 install_requires =
-    holidays==0.16
+    holidays>=0.16
 python_requires = >=3.7
 
 [options.package_data]


### PR DESCRIPTION
This is because since https://github.com/mj0nez/energy-datetime-utils/commit/1683b59f038ea67101409440ca61757837ed9c5d we're testing against 0.18